### PR TITLE
dvc: turn off analytics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: install requirements
         run: pip install -r requirements.txt
+      - name: turn off dvc's analytics
+        run: dvc config --global core.analytics false
       - name: check project styling
         if: matrix.os == 'ubuntu-latest'
         run: pre-commit run --all-files

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: install requirements
         run: pip install -r requirements.txt
+      - name: turn off dvc's analytics
+        run: dvc config --global core.analytics false
       - name: check project styling
         if: matrix.os == 'ubuntu-latest'
         run: pre-commit run --all-files

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -48,19 +48,14 @@ def init_git(path):
 
 def init_dvc(path, git=True):
     from dvc.repo import Repo
-    from dvc.main import main
 
     if git:
         init_git(path)
         repo = Repo.init(path)
         repo.scm.commit("Init DVC repo")
-        repo.close()
     else:
-        Repo.init(path, no_scm=True).close()
-
-    # turn off analytics with backward compatible method and reload
-    assert main(["config", "core.analytics", "false"]) == 0
-    return Repo(path)
+        repo = Repo.init(path, no_scm=True).close()
+    return repo
 
 
 def random_file(path, file_size):


### PR DESCRIPTION
Fixes #63 

It would be great to have reusable Github actions, though it seems its [not there yet](https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851/10) for now we have to repeat some steps per each workflow.