### PR TITLE
DVCIgnoreBench: increase timeout

### DIFF
--- a/benchmarks/status.py
+++ b/benchmarks/status.py
@@ -27,6 +27,8 @@ class DVCStatusBench(BaseBench):
 
 
 class DVCIgnoreBench(DVCStatusBench):
+    timeout = 300
+
     @staticmethod
     def add_ignore_rules(path, number):
         with open(os.path.join(path, DvcIgnore.DVCIGNORE_FILE), "w",) as f_w:


### PR DESCRIPTION
Related to #78 
[Test run](https://github.com/iterative/dvc-bench/actions/runs/140649664) seems to show that issue is fixed, lets wait for nightly build.
