### PR TITLE
asv: skip only succesfull runs

### DIFF
--- a/run_benchmarks.dvc
+++ b/run_benchmarks.dvc
@@ -1,5 +1,5 @@
 md5: b2d28dfd870ede2cc52afb58ceaaf8d8
-cmd: asv run HASHFILE:hashes.txt -k --profile --show-stderr
+cmd: asv run HASHFILE:hashes.txt --skip-existing-successful --profile --show-stderr
 deps:
 - md5: 9531dcc1c1aa3feb29c21b152f2b4a5c
   path: hashes.txt


### PR DESCRIPTION
So far our benchmarks are pretty basic, and they should be able to run on every version of dvc, so we should rerun existing and failed runs