### PR TITLE
results: copy by system name

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -82,9 +82,9 @@ jobs:
         run: dvc pull
       - name: join results
         run: |
-          cp -r /tmp/results-windows/* results/
-          cp -r /tmp/results-macos/* results/
-          cp -r /tmp/results-ubuntu/* results/
+          cp -r /tmp/results-windows/win* results/
+          cp -r /tmp/results-macos/darwin* results/
+          cp -r /tmp/results-ubuntu/linux* results/
       - name: commit results to dvc
         run: dvc commit -f run_benchmarks.dvc && dvc push
       - name: create PR for results

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -76,9 +76,9 @@ jobs:
         run: dvc pull
       - name: join results
         run: |
-          cp -r /tmp/results-windows/* results/
-          cp -r /tmp/results-macos/* results/
-          cp -r /tmp/results-ubuntu/* results/
+          cp -r /tmp/results-windows/win* results/
+          cp -r /tmp/results-macos/darwin* results/
+          cp -r /tmp/results-ubuntu/linux* results/
       - name: commit results to dvc
         run: dvc commit -f run_benchmarks.dvc && dvc push
       - name: create PR for results


### PR DESCRIPTION
Before this change we could override windows and darwin new build results with old ones contained in dvc remote. The reason for that was order of merging the results - ubuntu got copied in the end, and since we do `dvc pull` during workflow execution, we obtain also windows and darwin results, which later override new results for those systems. 