### PR TITLE
benchmark: fix default number of processes and repeat

### DIFF
--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -14,8 +14,8 @@ def sources_dir():
 class BaseBench:
     warmup_time = 0
     number = 1
-    repeat = (3, 5, 60.0)
-    processes = max(2, cpu_count() - 1)
+    repeat = 5
+    processes = 2
     timeout = 300
 
     def setup(self):


### PR DESCRIPTION
The number of processes means how many benchmark instances have to be run, so it is better to keep that number constant, in order to obtain results with same number of runs, independent of machine we are running on. Make repeat single number to not obfuscate how many times we actually run the benchmarks. It's hard enough as it is.