### PR TITLE
GH actions: public data for PR build

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -2,3 +2,6 @@
     remote = bench_s3
 ['remote "bench_s3"']
     url = s3://dvc-bench/cache
+    profile = dvc-bench
+['remote "bench_s3_public"']
+    url = https://remote.dvc.org/dvc-bench

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -25,5 +25,7 @@ jobs:
         run: python -m py.test
       - name: setup asv
         run: python write_asv_machine.py && asv check
+      - name: download data
+        run: dvc pull data/cats_dogs.dvc -r bench_s3_public
       - name: quick asv build of HEAD
         run: asv run --quick


### PR DESCRIPTION
PR builds for `Add` benchmarks has been failing due to lack of data. 