### PR TITLE
Sequential showcase

### DIFF
--- a/benchmarks/joined.py
+++ b/benchmarks/joined.py
@@ -1,0 +1,54 @@
+import shutil
+import timeit
+from collections import defaultdict
+from statistics import median
+
+from benchmarks.base import BaseBench
+
+
+class SequentialBench(BaseBench):
+    # NOTE: in case of `track` benchmarks this needs to be handled "by hand"
+    repeat = 3
+    timer = timeit.default_timer
+    units = "seconds"
+
+    def __init__(self):
+        self.results = {}
+        self.ran = False
+
+    def measure(self, *args):
+        start = self.timer()
+        self.dvc(*args)
+        return self.timer() - start
+
+    def setup_cache(self):
+        results = defaultdict(list)
+        for _ in range(self.repeat):
+            super().setup()
+
+            self.init_git()
+            self.init_dvc()
+
+            self.gen("data", template="cats_dogs")
+
+            # benchmark #1
+            results["time_add"].append(self.measure("add", "data", "--quiet"))
+
+            # setup #2
+            shutil.rmtree("data")
+
+            results["time_checkout"].append(
+                self.measure("checkout", "data.dvc")
+            )
+            super().teardown()
+
+        for key, measurements in results.items():
+            results[key] = median(measurements)
+
+        return results
+
+    def track_time_add(self, results):
+        return results["time_add"]
+
+    def track_time_checkout(self, results):
+        return results["time_checkout"]


### PR DESCRIPTION
Sample of how we can approach sequential benchmarks.
Based on https://github.com/airspeed-velocity/asv/issues/446

EDIT:
What is going on in this PR:
We would like to have sequential benchmarks, that is benchmarks that can measure few operations in one benchmark, for example:
1. add dataset
2. push dataset
3. checkout dataset

Such benchmark would take much less time than preparing 3 separate benchmarks, which have to duplicate a lot of behavior between them. For example, if we want to benchmark checkout operation, we need to prepare it by:
1. add dataset
2. remove dataset
Point 1 is also operation that we would like to measure, so creating separate benchmarks takes additional time and should be avoided if possible.

`asv` by itself, does not support sequential benchmark, but we could workaround that (and still benefit from visualization part of `asv`) by running our benchmarks inside `setup_cache` method, save the results as dictionary and just load them on `track_{benchmark_name}`. The problem with that approach is that we cannot use `asv` benchmarks parameters like `number`, `repeat`, `processes` and so on, and need to handle it manually. Same goes for calculating the result - we need to calculate median `by hand`.