### PR TITLE
pipeline: fix repo handling

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: run tests
         run: python -m py.test
       - name: setup asv
-        run: python write_asv_machine.py && asv check
+        run: python write_asv_machine.py
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install requirements
         run: pip install -r requirements.txt
       - name: setup asv machine
-        run: python write_asv_machine.py && asv check
+        run: python write_asv_machine.py
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: run tests
         run: python -m py.test
       - name: setup asv
-        run: python write_asv_machine.py && asv check
+        run: python write_asv_machine.py
       - name: download data
         run: dvc pull data/cats_dogs.dvc -r bench_s3_public
       - name: quick asv build of HEAD

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,6 +1,6 @@
 stages:
   convert_tags:
-    cmd: python tags_to_sha.py
+    cmd: asv check && python tags_to_sha.py
     deps:
     - tags.txt
     - tags_to_sha.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 virtualenv==16.7.10
 git+https://github.com/airspeed-velocity/asv.git@160f21186e86698b5e9256587f3ccd36f7f44f37#egg=asv
 gitpython
-dvc[s3]==1.1.1
+dvc[s3]>=1.0.0
 awscli>=1.16.297
 pre-commit
 pytest

--- a/tags_to_sha.py
+++ b/tags_to_sha.py
@@ -1,6 +1,15 @@
 import os
+from contextlib import contextmanager
 
+from asv.config import Config
 from git import Repo
+
+
+@contextmanager
+def dvc_git_repo():
+    repo = Repo(Config.load("asv.conf.json").project)
+    yield repo
+    repo.close()
 
 
 def convert_to_sha(tags_filename="tags.txt", hashes_filename="hashes.txt"):
@@ -8,8 +17,8 @@ def convert_to_sha(tags_filename="tags.txt", hashes_filename="hashes.txt"):
     with open(tags_filename, "r") as fobj:
         tags.extend([l.strip() for l in fobj.readlines()])
 
-    git_repo = Repo("dvc")
-    hashes = [git_repo.commit(t).hexsha + os.linesep for t in tags]
+    with dvc_git_repo() as repo:
+        hashes = [repo.commit(t).hexsha + os.linesep for t in tags]
 
     with open(hashes_filename, "w") as fobj:
         fobj.writelines(hashes)


### PR DESCRIPTION
Fixes #76 
I was wrong in #76. The problem was that asv did not cloned the repository. The fix for that is to run `asv check` before accessing cloned `dvc` repo.