### PR TITLE
feed parsing: get regressions by last commit date

### DIFF
--- a/parse_feed.py
+++ b/parse_feed.py
@@ -1,29 +1,55 @@
-import calendar
 import datetime
 import os
+import re
 import time
 
 import feedparser
 
+from tags_to_sha import dvc_git_repo
 
-def get_entries_since(feed_url, days=1):
+
+def get_commits_from_link(link):
+    pattern = re.compile("commits=[0-9a-f]{40}-[0-9a-f]{40}")
+    pattern_single = re.compile("commits=[0-9a-f]{40}")
+
+    if pattern.search(link):
+        (result,) = pattern.findall(link)
+        return result.replace("commits=", "").split("-")
+    elif pattern_single.search(link):
+        (result,) = pattern_single.findall(link)
+        return [result.replace("commits=", "")]
+    raise Exception("Could not find commits in regression link!")
+
+
+def latest_commit_time(revs):
+    commit_times = []
+    with dvc_git_repo() as repo:
+        for r in revs:
+            commit_times.append(repo.commit(r).committed_date)
+
+    return sorted(commit_times)[-1]
+
+
+def get_new_regressions(feed_url, days=1):
     d = feedparser.parse(feed_url)
 
     current_time = int(time.time())
-    delta_time = datetime.timedelta(days=days).total_seconds()
+    delta_time = int(datetime.timedelta(days=days).total_seconds())
 
-    new_feed_entries = []
+    new_regressions = []
     for entry in d["entries"]:
-        updated_time = calendar.timegm(entry["updated_parsed"])
-        if current_time - updated_time <= delta_time:
-            new_feed_entries.append(entry)
+        revs = get_commits_from_link(entry["link"])
+        commit_time = latest_commit_time(revs)
+        if current_time - commit_time <= delta_time:
+            new_regressions.append(entry)
 
-    return new_feed_entries
+    return new_regressions
 
 
 def prepare_issue_file(entries):
     if not entries:
         return
+
     path = os.path.join(".github", "ISSUE_TEMPLATE.md")
 
     lines = [
@@ -43,5 +69,5 @@ def prepare_issue_file(entries):
 
 if __name__ == "__main__":
     feed = "https://iterative.github.io/dvc-bench/regressions.xml"
-    entries = get_entries_since(feed, 1)
+    entries = get_new_regressions(feed)
     prepare_issue_file(entries)


### PR DESCRIPTION
Fixes #191 
Fixes #183 

We used to base our regressions detections on `updated` date, which was the date of the run, not the regression introduction. Now we will base that check on the date of the commit that "introduced" the regression. (Let's not forget that we do not benchmark all commits, hence "")