### PR TITLE
regression check: clone dvc before parsing commits

### DIFF
--- a/.github/workflows/regression_check.yml
+++ b/.github/workflows/regression_check.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: install requirements
         run: pip install -r requirements.txt
+      - name: clone dvc repo
+        run: asv check
       - name: detect regression and prepare issue template
         run: python parse_feed.py
       - name: check issue template existence


### PR DESCRIPTION
Regression check stopped working after #192, because regression check workflow did not clone `dvc` repo before parsing the feed.