### PR TITLE
github actions: self hosted runner terraform script

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -10,10 +10,7 @@ env:
 jobs:
   build:
     name: run benchmarks
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
+    runs-on: dvc-runner
     steps:
       - uses: actions/setup-python@v2
         with:
@@ -22,7 +19,6 @@ jobs:
       - name: install requirements
         run: pip install -r requirements.txt
       - name: check project styling
-        if: matrix.os == 'ubuntu-18.04'
         run: pre-commit run --all-files
       - name: run tests
         run: python -m py.test
@@ -43,8 +39,11 @@ jobs:
       - name: upload raw results
         uses: actions/upload-artifact@v2
         with:
-          name: results-${{ matrix.os }}
+          name: results-aws-runner
           path: results
+      # FIXME some benchmarks don't clean up properly
+      - name: cleanupt tmp
+        run: rm -rf /tmp*
   publish:
     name: join results and publish
     needs: build
@@ -59,7 +58,7 @@ jobs:
       - name: download ubuntu results
         uses: actions/download-artifact@v2
         with:
-          name: results-ubuntu-18.04
+          name: results-aws-runner
           path: /tmp/results-ubuntu
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,10 +9,7 @@ env:
 jobs:
   build:
     name: run benchmarks
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
+    runs-on: dvc-runner
     steps:
       - uses: actions/setup-python@v2
         with:
@@ -32,17 +29,16 @@ jobs:
         run: dvc pull data/cats_dogs.dvc
       - name: download existing results
         run: aws s3 cp --recursive s3://dvc-bench/latest_results results
-      # we cannot be sure that main build has been done on current machine,
-      # so we need to repro whole build
-      - name: run benchmarks
-        run: dvc repro -f run_benchmarks
       - name: run benchmarks on latest master
         run: asv run --show-stderr
       - name: upload raw results
         uses: actions/upload-artifact@v2
         with:
-          name: results-${{ matrix.os }}
+          name: results-aws-runner
           path: results
+      # FIXME some benchmarks don't clean up properly
+      - name: cleanupt tmp
+        run: rm -rf /tmp*
   publish:
     name: join results and publish
     needs: build
@@ -57,7 +53,7 @@ jobs:
       - name: download ubuntu results
         uses: actions/download-artifact@v2
         with:
-          name: results-ubuntu-18.04
+          name: results-aws-runner
           path: /tmp/results-ubuntu
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [windows-2019, macos-10.15, ubuntu-18.04]
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-virtualenv==16.7.10
+virtualenv==20.0.8
 git+https://github.com/airspeed-velocity/asv.git@160f21186e86698b5e9256587f3ccd36f7f44f37#egg=asv
 gitpython
 dvc[s3]>=1.0.0

--- a/runner/.gitignore
+++ b/runner/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,0 +1,9 @@
+# To destroy existing instance:
+
+`AWS_PROFILE={profile} terraform destroy`
+
+*where profile is profile with access to `dvc-bench` bucket.*
+
+# To create new instance:
+
+`AWS_PROFILE={profile} terraform apply`

--- a/runner/main.tf
+++ b/runner/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  backend "s3" {
+    bucket = "dvc-bench"
+    key    = "terraform/config"
+    region = "us-east-2"
+  }
+}
+
+provider "aws" {
+  region                  = var.region
+  shared_credentials_file = var.aws_credentials_path
+  profile                 = var.aws_profile
+}
+
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+resource "aws_security_group" "ip_ssh" {
+  name        = "dvc-bench-runner-ip-ssh"
+  description = "Security group for the inlets server"
+
+  /* SSH */
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.myip.body)}/32"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "runner" {
+  ami                    = "ami-0bbe28eb2173f6167"
+  instance_type          = "t3.micro"
+  key_name               = var.key_name
+  vpc_security_group_ids = [aws_security_group.ip_ssh.id]
+  root_block_device {
+    volume_size = 40
+  }
+  tags = {
+    Name = "dvc-bench-runner"
+  }
+}
+
+resource "null_resource" "gha_runner_setup" {
+
+  provisioner "local-exec" {
+    command = "aws ec2 wait instance-running --region ${var.region} --profile ${var.aws_profile} --instance-ids ${aws_instance.runner.id}"
+  }
+
+  connection {
+    type        = "ssh"
+    host        = aws_instance.runner.public_dns
+    user        = var.ssh_user
+    private_key = file(var.private_key_path)
+    timeout     = "30s"
+  }
+
+  provisioner "file" {
+    source      = "setup_github_actions_runner.sh"
+    destination = "/tmp/setup.sh"
+
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "apt-get update",
+      "chmod +x /tmp/setup.sh",
+      "/tmp/setup.sh ${var.github_token}",
+      "nohup ~/actions-runner/run.sh &",
+      "sleep 1"
+    ]
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"to connect: ssh -i '${var.private_key_path}' ${var.ssh_user}@${aws_instance.runner.public_dns}\""
+  }
+}

--- a/runner/main.tf
+++ b/runner/main.tf
@@ -73,7 +73,7 @@ resource "null_resource" "gha_runner_setup" {
     inline = [
       "apt-get update",
       "chmod +x /tmp/setup.sh",
-      "/tmp/setup.sh ${var.github_token}",
+      "/tmp/setup.sh ${var.actions_runner_version} ${var.github_token}",
       "nohup ~/actions-runner/run.sh &",
       "sleep 1"
     ]

--- a/runner/setup_github_actions_runner.sh
+++ b/runner/setup_github_actions_runner.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sudo apt update
+sudo add-apt-repository ppa:deadsnakes/ppa -y
+sudo add-apt-repository ppa:git-core/ppa -y
+sudo apt install software-properties-common python3.7 python3.7-dev git -y
+
+mkdir ~/actions-runner 
+cd ~/actions-runner
+curl -O -L https://github.com/actions/runner/releases/download/v2.272.0/actions-runner-linux-x64-2.272.0.tar.gz
+tar xzf ./actions-runner-linux-x64-2.272.0.tar.gz
+rm actions-runner-linux-x64-2.272.0.tar.gz
+./config.sh --url https://github.com/iterative/dvc-bench --token $1 --name dvc-runner --labels 'dvc-runner' --work '_work' --replace

--- a/runner/setup_github_actions_runner.sh
+++ b/runner/setup_github_actions_runner.sh
@@ -6,7 +6,7 @@ sudo apt install software-properties-common python3.7 python3.7-dev git -y
 
 mkdir ~/actions-runner 
 cd ~/actions-runner
-curl -O -L https://github.com/actions/runner/releases/download/v2.272.0/actions-runner-linux-x64-2.272.0.tar.gz
-tar xzf ./actions-runner-linux-x64-2.272.0.tar.gz
-rm actions-runner-linux-x64-2.272.0.tar.gz
-./config.sh --url https://github.com/iterative/dvc-bench --token $1 --name dvc-runner --labels 'dvc-runner' --work '_work' --replace
+curl -L https://github.com/actions/runner/releases/download/v$1/actions-runner-linux-x64-$1.tar.gz -o runner.tar.gz
+tar xzf ./runner.tar.gz
+rm runner.tar.gz
+./config.sh --url https://github.com/iterative/dvc-bench --token $2 --name dvc-runner --labels 'dvc-runner' --work '_work' --replace

--- a/runner/variables.tf
+++ b/runner/variables.tf
@@ -1,0 +1,21 @@
+variable "aws_profile" {
+  description = "AWS profile name"
+}
+variable "aws_credentials_path" {
+  description = "Path to AWS credentials"
+}
+variable "github_token" {
+  description = "Github actions token from https://github.com/iterative/dvc-bench/settings/actions/add-new-runner"
+}
+variable "key_name" {
+  description = "Name of your SSH key pair in Amazon EC2."
+}
+variable "private_key_path" {
+  description = "Path to the private SSH key (.pem), used to access the instance."
+}
+variable "ssh_user" {
+  description = "SSH user name to connect to your instance."
+}
+variable "region" {
+  description = "Region of our instance"
+}

--- a/runner/variables.tf
+++ b/runner/variables.tf
@@ -19,3 +19,6 @@ variable "ssh_user" {
 variable "region" {
   description = "Region of our instance"
 }
+variable "actions_runner_version" {
+  description = "Latest version of actions runner from https://github.com/actions/runner/releases/latest (omit 'v')"
+}


### PR DESCRIPTION
Fixes #203 

In this change, we create a terraform script that will be responsible for managing our own github actions runner.
That way we will have a constant execution environment, also, we should be more timeout-proof (github actions timeout for self-hosted runner is 72hrs (versus current 6hrs)).

I noticed that `/tmp` sometimes does not get cleaned up, so for now I introduced workaround cleaning it after each build. Need to investigate, as I am unable to reproduce on my own computer. Will create issue for that after this change gets accepted.