### PR TITLE
Cleanup /tmp on setup

### DIFF
--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -50,6 +50,8 @@ class BaseBench:
     timeout = 300
 
     def setup(self, *params):
+        # workaround for gha not using teardown
+        self._cleanup_tmp()
         self.cwd = os.getcwd()
         self.test_directory = TemporaryDirectory(
             prefix="benchmark_{}_".format(self.__class__.__name__)
@@ -97,3 +99,12 @@ class BaseBench:
 
     def gen(self, repo_path, template):
         shutil.copytree(DATA_TEMPLATES[template], repo_path)
+
+    def _cleanup_tmp(self):
+        assert self.processes == 1
+
+        tmp = gettempdir()
+        tmp_ls = os.listdir(tmp)
+        for path in tmp_ls:
+            if path.startswith("benchmark_") and os.path.isdir(path):
+                shutil.rmtree(os.path.join(tmp, path))

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -51,7 +51,9 @@ class BaseBench:
 
     def setup(self, *params):
         self.cwd = os.getcwd()
-        self.test_directory = TemporaryDirectory(prefix="DVCBenchmark")
+        self.test_directory = TemporaryDirectory(
+            prefix="benchmark_{}_".format(self.__class__.__name__)
+        )
         os.chdir(self.path)
 
     @property

--- a/benchmarks/push.py
+++ b/benchmarks/push.py
@@ -1,5 +1,3 @@
-from subprocess import Popen
-
 import shortuuid
 
 from benchmarks.base import BaseBench
@@ -16,17 +14,12 @@ class PushBench(BaseBench):
         self.init_dvc()
 
         self.remote_url = (
-            f"s3://dvc-bench/tmp-benchmarks-cache-{shortuuid.uuid()}"
+            f"s3://dvc-temp/tmp-benchmarks-cache-{shortuuid.uuid()}"
         )
         self.dvc("remote", "add", "-d", "storage", self.remote_url)
 
         self.gen("data", template="cats_dogs")
         self.dvc("add", "data", "--quiet")
-
-    def teardown(self, *params):
-        Popen(
-            ["aws", "s3", "rm", self.remote_url, "--recursive"], close_fds=True
-        )
 
     def time_cats_dogs(self):
         self.dvc("push", "-j", "2")


### PR DESCRIPTION
Workaround for #207 
Since we are using only 1 process, we can cleanup `/tmp` before running `_setup`.
This is not a solution to #207.
I just need to get my hands on log, which is impossible if the step isn't [finished](https://github.com/iterative/dvc-bench/runs/1030350353?check_suite_focus=true)