### PR TITLE
Increase imports timeout

### DIFF
--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -3,7 +3,7 @@ from benchmarks.base import BaseBench
 
 class ImportBench(BaseBench):
     repeat = 1
-    timeout = 2000
+    timeout = 6000
 
     def setup(self):
         super().setup()


### PR DESCRIPTION
Looks like https://github.com/iterative/dvc/issues/4485 improved performance by >10  times. So, in recent master, it seems it finished in ~10m.
So, 10 * 10 * 60 = 6000. 

I'll reduce it after checking the logs after this gets built.