### PR TITLE
github actions workflows: roll back migration to environmental files

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -4,14 +4,15 @@ on:
     branches:
       - master
 
+env:
+  DVC_TEST: "true"
+
 jobs:
   build:
     timeout-minutes: 4320
     name: run benchmarks
     runs-on: dvc-runner
     steps:
-      - name: set up environment variables
-        run: echo 'DVC_TEST=true' >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
             python-version: 3.7

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -3,14 +3,15 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+env:
+  DVC_TEST: "true"
+
 jobs:
   build:
     timeout-minutes: 4320
     name: run benchmarks
     runs-on: dvc-runner
     steps:
-      - name: set up environment variables
-        run: echo 'DVC_TEST=true' >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
             python-version: 3.7

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -1,6 +1,9 @@
 name: pull request build
 on: [pull_request]
 
+env:
+  DVC_TEST: "true"
+
 jobs:
   verify:
     name: tests, styling and quick asv run
@@ -9,8 +12,6 @@ jobs:
       matrix:
         os: [windows-2019, macos-10.15, ubuntu-18.04]
     steps:
-      - name: set up environment variables
-        run: echo 'DVC_TEST=true' >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7

--- a/.github/workflows/regression_check.yml
+++ b/.github/workflows/regression_check.yml
@@ -26,13 +26,14 @@ jobs:
       - name: create issue
         if: steps.check_files.outputs.files_exists == 'true'
         id: create-issue
-        run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
         uses: JasonEtco/create-an-issue@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: ping slack
         if: steps.check_files.outputs.files_exists == 'true'
         uses: rtCamp/action-slack-notify@v2.0.2
-        run: |
-          echo 'SLACK_WEBHOOK=${{ secrets.SLACK_WEBHOOK }}' >> $GITHUB_ENV
-          echo 'SLACK_MESSAGE=${{ steps.create-issue.outputs.url }}' >> $GITHUB_ENV
-          echo 'SLACK_ICON=https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png' >> $GITHUB_ENV
-          echo 'SLACK_USERNAME=regressionBot' >> $GITHUB_ENV
+        env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+            SLACK_MESSAGE: ${{ steps.create-issue.outputs.url }}
+            SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+            SLACK_USERNAME: "regressionBot"


### PR DESCRIPTION
Seems like I was wrong to think that warnings popping up during build refer to our use of env:
https://github.community/t/environmental-files-on-windows/137631