### PR TITLE
benchs: add import-url --to-remote benchmark

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,5 +17,5 @@
         "startup.*": 0.25,
         "status.*": 0.25
     },
-    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}[all]"]
+    "install_command": ["in-dir={env_dir} python -mpip install s3fs {wheel_file}[all]"]
 }

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -6,6 +6,9 @@ from multiprocessing import cpu_count
 from subprocess import PIPE, Popen
 from tempfile import TemporaryDirectory, gettempdir
 
+import shortuuid
+from funcy import cached_property
+
 from dvc.main import main
 
 
@@ -36,6 +39,7 @@ def random_data_dir(num_files, file_size):
 
 
 DATA_TEMPLATES = {
+    "mini": random_data_dir(100, 1024),
     "small": random_data_dir(2000, 1024),
     "large": random_data_dir(10000, 1024),
     "cats_dogs": os.path.join(os.environ["ASV_CONF_DIR"], "data", "cats_dogs"),
@@ -117,3 +121,37 @@ class BaseBench:
                 shutil.rmtree(os.path.join(tmp, path))
             elif path.startswith("tmp") and os.path.isfile(path):
                 os.remove(os.path.join(tmp, path))
+
+
+class BaseRemoteBench(BaseBench):
+
+    _remote_prefix = "dvc-temp/dvc-bench"
+
+    def setup(self):
+        super().setup()
+
+        self.init_git()
+        self.init_dvc()
+
+        remote_url = (
+            self._remote_prefix + f"/temp-benchmarks-cache-{shortuuid.uuid()}"
+        )
+        self.dvc("remote", "add", "-d", "storage", f"s3://{remote_url}")
+
+    def setup_data(self, template):
+        data_url = self._remote_prefix + f"/tmp-benchmarks-data/{template}"
+        if self.fs.exists(data_url):
+            return data_url
+
+        local_url = f"_tmp_data_{template}"
+        self.gen(local_url, template)
+
+        self.fs.put(local_url, data_url, recursive=True)
+        shutil.rmtree(local_url)
+        return data_url
+
+    @cached_property
+    def fs(self):
+        from s3fs import S3FileSystem
+
+        return S3FileSystem()

--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -1,4 +1,4 @@
-from benchmarks.base import BaseBench
+from benchmarks.base import BaseBench, BaseRemoteBench
 
 
 class ImportBench(BaseBench):
@@ -15,3 +15,16 @@ class ImportBench(BaseBench):
         repo = f"file://{self.project_dir}"
         path = "data/cats_dogs"
         self.dvc("import", repo, path, proc=True)
+
+
+class ImportUrlToRemoteBench(BaseRemoteBench):
+    repeat = 1
+    timeout = 12000
+
+    def __init__(self):
+        super().__init__()
+        self.data_url = self.setup_data("mini")
+
+    def time_import_url_to_remote(self):
+        print("STARTING", file=__import__("sys").stderr)
+        self.dvc("import-url", self.data_url, "--to-remote")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,8 @@ virtualenv==20.0.8
 git+https://github.com/airspeed-velocity/asv.git@160f21186e86698b5e9256587f3ccd36f7f44f37#egg=asv
 gitpython
 dvc[s3]>=1.0.0
-awscli
-s3fs
+awscli>=1.16.297
 pre-commit
 pytest
 pytest-mock
 feedparser
-funcy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@ virtualenv==20.0.8
 git+https://github.com/airspeed-velocity/asv.git@160f21186e86698b5e9256587f3ccd36f7f44f37#egg=asv
 gitpython
 dvc[s3]>=1.0.0
-awscli>=1.16.297
+awscli
+s3fs
 pre-commit
 pytest
 pytest-mock
 feedparser
+funcy

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ select=B,C,E,F,W,T4,B9
 [isort]
 include_trailing_comma=true
 known_first_party=benchmarks,dvc
-known_third_party=asv,feedparser,git,pytest,shortuuid
+known_third_party=asv,feedparser,funcy,git,pytest,shortuuid
 line_length=79
 multi_line_output=3


### PR DESCRIPTION
Add `import-url --to-remote` benchmarks as per #246. This also introduces a base class called `BaseRemoteBench` which helps setting up data in a remote location and also creates a dvc remote (will be useful for other benchmarks, such as to-cache/update --to-remote). 