### PR TITLE
gh: use checkout to get the downloaded data

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .dvc/cache
-          key: ${{ hashFiles('**/*.dvc') }}
+          key: ${{ runner.os }}-data-${{ hashFiles('**/*.dvc') }}
       - name: download data
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: dvc fetch data/cats_dogs.dvc

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -35,6 +35,6 @@ jobs:
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: dvc fetch data/cats_dogs.dvc
       - name: checkout data
-        run: dvc checkout data/cats_dogs.dvc
+        run: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD
         run: asv run --quick

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -26,14 +26,11 @@ jobs:
       - name: setup asv
         run: python write_asv_machine.py
       - name: cache data
-        id: cache-data
+        if: matrix.os != 'windows-2019'
         uses: actions/cache@v2
         with:
           path: .dvc/cache
           key: ${{ runner.os }}-data-${{ hashFiles('**/*.dvc') }}
-      - name: download data
-        if: steps.cache-data.outputs.cache-hit != 'true'
-        run: dvc fetch data/cats_dogs.dvc
       - name: checkout data
         run: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: .dvc/cache
           key: ${{ runner.os }}-data-${{ hashFiles('**/*.dvc') }}
-      - name: checkout data
+      - name: pull data
         run: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD
         run: asv run --quick

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -25,6 +25,12 @@ jobs:
         run: python -m py.test
       - name: setup asv
         run: python write_asv_machine.py
+      - name: cache data
+        id: cache-data
+        uses: actions/cache@v2
+        with:
+          path: .dvc/cache
+          key: ${{ hashFiles('**/*.dvc') }}
       - name: download data
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: dvc fetch data/cats_dogs.dvc

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -25,14 +25,10 @@ jobs:
         run: python -m py.test
       - name: setup asv
         run: python write_asv_machine.py
-      - name: cache data
-        id: cache-data
-        uses: actions/cache@v2
-        with:
-          path: data/cats_dogs
-          key: ${{ hashFiles('data/cats_dogs.dvc') }}
       - name: download data
         if: steps.cache-data.outputs.cache-hit != 'true'
-        run: dvc pull data/cats_dogs.dvc
+        run: dvc fetch data/cats_dogs.dvc
+      - name: checkout data
+        run: dvc checkout data/cats_dogs.dvc
       - name: quick asv build of HEAD
         run: asv run --quick


### PR DESCRIPTION
Now, instead of caching the `data/cats_dogs` it caches the `.dvc/cache`. Also in the later step it only fetches and for both cases, it uses `dvc checkout`. 