### PR TITLE
benchs: add update benchmarks (for regular/to-remote import-url)

### DIFF
--- a/benchmarks/add.py
+++ b/benchmarks/add.py
@@ -24,7 +24,7 @@ class Add(BaseBench):
 class AddToCache(BaseRemoteBench):
     def setup(self):
         super().setup()
-        self.data_url = self._remote_prefix + self.setup_data("mini")
+        self.data_url = self._remote_prefix + self.setup_data("100x1024")
 
     def time_add_to_cache(self):
         self.dvc("add", self.data_url, "-o", "mini", proc=True)

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -39,7 +39,8 @@ def random_data_dir(num_files, file_size):
 
 
 DATA_TEMPLATES = {
-    "mini": random_data_dir(100, 1024),
+    "100x1024": random_data_dir(100, 1024),
+    "200x1024": random_data_dir(200, 1024),
     "small": random_data_dir(2000, 1024),
     "large": random_data_dir(10000, 1024),
     "cats_dogs": os.path.join(os.environ["ASV_CONF_DIR"], "data", "cats_dogs"),
@@ -141,8 +142,13 @@ class BaseRemoteBench(BaseBench):
         )
         self.dvc("remote", "add", "-d", "storage", remote_url)
 
-    def setup_data(self, template):
-        data_url = self._remote_dir + f"/tmp-benchmarks-data/{template}"
+    def setup_data(self, template, name=None):
+        if name is None:
+            name = template
+        else:
+            name = f"data-{name}-{shortuuid.uuid()}"
+
+        data_url = self._remote_dir + f"/tmp-benchmarks-data/{name}"
         if self.fs.exists(data_url):
             return data_url
 

--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -23,10 +23,10 @@ class ImportUrlBench(BaseRemoteBench):
 
     def setup(self):
         super().setup()
-        self.data_url = self._remote_prefix + self.setup_data("mini")
+        self.data_url = self._remote_prefix + self.setup_data("100x1024")
 
     def time_import_url(self):
-        self.dvc("Import-url", self.data_url, proc=True)
+        self.dvc("import-url", self.data_url, proc=True)
 
 
 class ImportUrlToRemoteBench(BaseRemoteBench):
@@ -35,7 +35,7 @@ class ImportUrlToRemoteBench(BaseRemoteBench):
 
     def setup(self):
         super().setup()
-        self.data_url = self._remote_prefix + self.setup_data("mini")
+        self.data_url = self._remote_prefix + self.setup_data("100x1024")
 
     def time_import_url_to_remote(self):
         self.dvc("import-url", self.data_url, "--to-remote", proc=True)

--- a/benchmarks/update.py
+++ b/benchmarks/update.py
@@ -1,0 +1,34 @@
+from benchmarks.base import BaseRemoteBench
+
+
+class UpdateImportUrlBench(BaseRemoteBench):
+    repeat = 1
+    timeout = 12000
+
+    def setup(self):
+        super().setup()
+        self.data_url = self.setup_data("100x1024", name="update-data")
+        self.dvc("import-url", self._remote_prefix + self.data_url, "stage")
+        self.setup_data("200x1024", name="update-data")
+
+    def time_import_url(self):
+        self.dvc("update", "stage.dvc", proc=True)
+
+
+class UpdateImportUrlToRemoteBench(BaseRemoteBench):
+    repeat = 1
+    timeout = 12000
+
+    def setup(self):
+        super().setup()
+        self.data_url = self.setup_data("100x1024", name="update-data")
+        self.dvc(
+            "import-url",
+            self._remote_prefix + self.data_url,
+            "stage",
+            "--to-remote",
+        )
+        self.setup_data("200x1024", name="update-data")
+
+    def time_import_url_to_remote(self):
+        self.dvc("update", "stage.dvc", "--to-remote", proc=True)


### PR DESCRIPTION
I couldn't find a name for a slightly bigger `mini` dataset, so I renamed it to 100x1024 and used 200x1024 for the bigger one. 