### PR TITLE
bench: stabilize contents for the same files

### DIFF
--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -21,6 +21,11 @@ def sources_dir():
 
 @lru_cache(None)
 def get_data_for_file(path, file_size):
+    # This function will generate the same data for the same path,
+    # which would allow to make datasets grow on top of the existing
+    # ones. The `path` is a key to this function's caching system, and
+    # even if it is not used, it needs to be present in the signature to
+    # allow cache lookups.
     return os.urandom(file_size)
 
 

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 from concurrent.futures import ThreadPoolExecutor
+from functools import lru_cache
 from multiprocessing import cpu_count
 from subprocess import PIPE, Popen
 from tempfile import TemporaryDirectory, gettempdir
@@ -18,9 +19,14 @@ def sources_dir():
     return path
 
 
+@lru_cache(None)
+def get_data_for_file(path, file_size):
+    return os.urandom(file_size)
+
+
 def random_file(path, file_size):
     with open(path, "wb") as fobj:
-        fobj.write(os.urandom(file_size))
+        fobj.write(get_data_for_file(path, file_size))
 
 
 def random_data_dir(num_files, file_size):
@@ -110,8 +116,10 @@ class BaseBench:
         no_scm = not os.path.exists(".git")
         Repo.init(self.path, no_scm=no_scm).close()
 
-    def gen(self, repo_path, template):
-        shutil.copytree(DATA_TEMPLATES[template], repo_path)
+    def gen(self, repo_path, template, exist_ok=False):
+        shutil.copytree(
+            DATA_TEMPLATES[template], repo_path, dir_exist_ok=exist_ok
+        )
 
     def _cleanup_tmp(self):
         assert self.processes == 1
@@ -154,7 +162,7 @@ class BaseRemoteBench(BaseBench):
             return data_url
 
         local_url = f"_tmp_data_{template}"
-        self.gen(local_url, template)
+        self.gen(local_url, template, exist_ok=True)
 
         self.fs.put(local_url, data_url, recursive=True)
         shutil.rmtree(local_url)

--- a/benchmarks/status.py
+++ b/benchmarks/status.py
@@ -47,7 +47,7 @@ class StatusCloudMissingFilesBench(StatusCloudBench):
 
     def setup(self):
         super().setup()
-        self.gen("data", "large")
+        self.gen("data", "large", exist_ok=True)
         self.dvc("add", "data", "--quiet")
 
     def time_status_c_with_missing(self):


### PR DESCRIPTION
Resolves #262. Now every `file_1` will have the same content, so if you initially create a `medium` sized data dir and then create a `large` one DVC will able to tell you that the 5000 files already exist on the remote and 5000 files are new in your local environment instead of claiming every one of those are changed. 