### PR TITLE
bench: use dvc 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dvc/
 /results
 html/
 /benchmarks_log
-dvc.lock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 virtualenv==20.0.8
 git+https://github.com/airspeed-velocity/asv.git@160f21186e86698b5e9256587f3ccd36f7f44f37#egg=asv
 gitpython
-dvc[s3]>=1.0.0
+dvc[s3]>=2.0.0
 awscli>=1.16.297
 pre-commit
 pytest


### PR DESCRIPTION
Fixes #255 
I though migration to 2.0 will be harder. We do not rely on our dvc.lock when pulling (the only thing that we need to pull is data that has its own dvc files). `dvc.lock` was a problem when we were creating automated pull requests. But we do not do that  since #168. So we can just stop ignoring dvc.lock. Also, taking a look at #168 we can consider getting back to it - the reason for not using dvc back then was lack of builds per machine, which (might) be solved by parametrized stages.