### PR TITLE
asv build fixes

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -34,4 +34,4 @@ jobs:
       - name: pull data
         run: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD
-        run: asv run --quick
+        run: asv run --quick -e

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,5 +17,5 @@
         "startup.*": 0.25,
         "status.*": 0.25
     },
-    "install_command": ["in-dir={env_dir} python -mpip install s3fs {wheel_file}[all]"]
+    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}[all]"]
 }


### PR DESCRIPTION
On wrong argument call fixed.
As to asv installation script, we include s3fs with `all` (in dvc) so no need to keep it there.