### PR TITLE
builds: retry build if failed

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -38,7 +38,10 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: download data
-        run: dvc pull data/cats_dogs.dvc
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 5
+          command: dvc pull data/cats_dogs.dvc
       - name: download existing results
         run: aws s3 cp --recursive s3://dvc-bench/latest_results results
       - name: run benchmarks

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -40,6 +40,7 @@ jobs:
       - name: download data
         uses: nick-invision/retry@v2
         with:
+          timeout_minutes: 30
           max_attempts: 5
           command: dvc pull data/cats_dogs.dvc
       - name: download existing results

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -33,7 +33,10 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: download data
-        run: dvc pull data/cats_dogs.dvc
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 5
+          command: dvc pull data/cats_dogs.dvc
       - name: download existing results
         run: aws s3 cp --recursive s3://dvc-bench/latest_results results
       - name: run benchmarks on latest master

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: download data
         uses: nick-invision/retry@v2
         with:
+          timeout_minutes: 30
           max_attempts: 5
           command: dvc pull data/cats_dogs.dvc
       - name: download existing results

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -34,6 +34,7 @@ jobs:
       - name: pull data
         uses: nick-invision/retry@v2
         with:
+          timeout_minutes: 30
           max_attempts: 5
           command: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -32,6 +32,9 @@ jobs:
           path: .dvc/cache
           key: ${{ runner.os }}-data-${{ hashFiles('**/*.dvc') }}
       - name: pull data
-        run: dvc pull data/cats_dogs.dvc
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 5
+          command: dvc pull data/cats_dogs.dvc
       - name: quick asv build of HEAD
         run: asv run --quick -e


### PR DESCRIPTION
For download data step, we start using action that is supposed to retry the step if failed. It  seems that our builds fail quite often due to 500/503/522 errors on our aws serving public dataset.