### PR TITLE
benchs: repeat=1 for all remote benchmarks

### DIFF
--- a/benchmarks/add.py
+++ b/benchmarks/add.py
@@ -22,9 +22,6 @@ class Add(BaseBench):
 
 
 class AddToCache(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
         self.data_url = self.setup_data("100x1024")

--- a/benchmarks/add.py
+++ b/benchmarks/add.py
@@ -22,6 +22,9 @@ class Add(BaseBench):
 
 
 class AddToCache(BaseRemoteBench):
+    repeat = 1
+    timeout = 12000
+
     def setup(self, remote):
         super().setup(remote)
         self.data_url = self.setup_data("100x1024")

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -154,6 +154,11 @@ def get_fs(filesystem, **kwargs):
 
 class BaseRemoteBench(BaseBench):
 
+    # For benchmarks that interact with remotes
+    # only run them once
+    repeat = 1
+    timeout = 12_000
+
     params = config["remotes"].keys()
 
     DEFAULT_REMOTE = "storage"

--- a/benchmarks/gc.py
+++ b/benchmarks/gc.py
@@ -2,6 +2,9 @@ from benchmarks.base import BaseBench, BaseRemoteBench
 
 
 class GCBench(BaseBench):
+    repeat = 1
+    timeout = 12000
+
     def setup(self):
         super().setup()
 

--- a/benchmarks/gc.py
+++ b/benchmarks/gc.py
@@ -2,9 +2,6 @@ from benchmarks.base import BaseBench, BaseRemoteBench
 
 
 class GCBench(BaseBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self):
         super().setup()
 
@@ -21,9 +18,6 @@ class GCBench(BaseBench):
 
 
 class CloudGCBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
 

--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -2,9 +2,6 @@ from benchmarks.base import BaseBench, BaseRemoteBench
 
 
 class ImportBench(BaseBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self):
         super().setup()
 
@@ -18,9 +15,6 @@ class ImportBench(BaseBench):
 
 
 class ImportUrlBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
         self.data_url = self.setup_data("100x1024")
@@ -30,9 +24,6 @@ class ImportUrlBench(BaseRemoteBench):
 
 
 class ImportUrlToRemoteBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
         self.data_url = self.setup_data("100x1024")

--- a/benchmarks/imports.py
+++ b/benchmarks/imports.py
@@ -2,6 +2,9 @@ from benchmarks.base import BaseBench, BaseRemoteBench
 
 
 class ImportBench(BaseBench):
+    repeat = 1
+    timeout = 12000
+
     def setup(self):
         super().setup()
 

--- a/benchmarks/pull.py
+++ b/benchmarks/pull.py
@@ -5,9 +5,6 @@ from benchmarks.base import BaseRemoteBench
 
 
 class PullBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
 

--- a/benchmarks/push.py
+++ b/benchmarks/push.py
@@ -2,9 +2,6 @@ from benchmarks.base import BaseRemoteBench
 
 
 class PushBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
 

--- a/benchmarks/status.py
+++ b/benchmarks/status.py
@@ -27,9 +27,6 @@ class DVCStatusBench(BaseBench):
 
 
 class StatusCloudBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 1200
-
     def setup(self, remote):
         super().setup(remote)
 
@@ -42,9 +39,6 @@ class StatusCloudBench(BaseRemoteBench):
 
 
 class StatusCloudMissingFilesBench(StatusCloudBench):
-    repeat = 1
-    timeout = 1200
-
     def setup(self, remote):
         super().setup(remote)
 

--- a/benchmarks/update.py
+++ b/benchmarks/update.py
@@ -2,9 +2,6 @@ from benchmarks.base import BaseRemoteBench
 
 
 class UpdateImportUrlBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
         data_url = self.setup_data("100x1024")
@@ -16,9 +13,6 @@ class UpdateImportUrlBench(BaseRemoteBench):
 
 
 class UpdateImportUrlToRemoteBench(BaseRemoteBench):
-    repeat = 1
-    timeout = 12000
-
     def setup(self, remote):
         super().setup(remote)
         data_url = self.setup_data("100x1024")


### PR DESCRIPTION
While browsing the benchmark logs I noticed that the add to cache benchmarks ran multiple times, which is something that we don't do for other remotes (because they tend to take a lot of time). So I've added `repeat=1` and `timeout=12000` to the `BaseRemoteBench`. If needed the subclasses can override those limits but I think they are fine as defaults. 