### PR TITLE
benchs: initialize dvc/git for gc

### DIFF
--- a/benchmarks/gc.py
+++ b/benchmarks/gc.py
@@ -8,6 +8,9 @@ class GCBench(BaseBench):
     def setup(self):
         super().setup()
 
+        self.init_git()
+        self.init_dvc()
+
         self.gen("data", "cats_dogs")
         self.dvc("add", "data", "--quiet")
         self.dvc("push", "data", "--quiet")
@@ -32,7 +35,7 @@ class CloudGCBench(BaseRemoteBench):
         self.dvc("push", "data", "--quiet")
 
         # remove everything from the local system
-        self.dvc("remove", "data")
+        self.dvc("remove", "data.dvc")
         self.dvc("gc", "-w")
 
     def time_gc_cloud(self, _):


### PR DESCRIPTION
A couple problems related gc benchmark:
- Normal gc benchmark doesn't initialize dvc/git.
- Cloud gc benchmark uses the raw dataset name without the `.dvc` prefix

this patch resolves those issues. 