### PR TITLE
[WIP] update: debug failures

### DIFF
--- a/benchmarks/update.py
+++ b/benchmarks/update.py
@@ -5,7 +5,7 @@ class UpdateImportUrlBench(BaseRemoteBench):
     def setup(self, remote):
         super().setup(remote)
         data_url = self.setup_data("100x1024")
-        self.dvc("import-url", data_url, "stage")
+        self.dvc("import-url", data_url, "stage", "-v")
         self.setup_data("200x1024", url=data_url)
 
     def time_import_url_to_remote(self, _):
@@ -17,7 +17,7 @@ class UpdateImportUrlToRemoteBench(BaseRemoteBench):
         super().setup(remote)
         raw_data_url = self.setup_data("100x1024", wrap=False)
         self.dvc(
-            "import-url", self.wrap(raw_data_url), "stage", "--to-remote",
+            "import-url", self.wrap(raw_data_url), "stage", "--to-remote", "-v",
         )
         self.setup_data("200x1024", url=raw_data_url)
 

--- a/benchmarks/update.py
+++ b/benchmarks/update.py
@@ -9,7 +9,7 @@ class UpdateImportUrlBench(BaseRemoteBench):
         self.setup_data("200x1024", url=data_url)
 
     def time_import_url_to_remote(self, _):
-        self.dvc("update", "stage.dvc", proc=True)
+        self.dvc("update", "stage.dvc", "-v", proc=True)
 
 
 class UpdateImportUrlToRemoteBench(BaseRemoteBench):
@@ -22,4 +22,4 @@ class UpdateImportUrlToRemoteBench(BaseRemoteBench):
         self.setup_data("200x1024", url=raw_data_url)
 
     def time_import_url_to_remote(self, _):
-        self.dvc("update", "stage.dvc", "--to-remote", proc=True)
+        self.dvc("update", "stage.dvc", "--to-remote", "-v", proc=True)


### PR DESCRIPTION
`update` benches have been missing results for awhile:
![image](https://user-images.githubusercontent.com/5367102/129249758-1d515c9f-79ee-4a18-b9d1-d36b37267565.png)
Part of #292

Our current benchmarks don't react in any way to failures, see #283 :slightly_frowning_face:If this is asv limitation - more reasons to move to pytest-benchmark.