### PR TITLE
benchmarks: remove quiet options

### DIFF
--- a/benchmarks/add.py
+++ b/benchmarks/add.py
@@ -15,10 +15,10 @@ class Add(BaseBench):
 
         self.gen("data", template="cats_dogs")
 
-        self.dvc("config", "cache.type", link_type, "--quiet")
+        self.dvc("config", "cache.type", link_type)
 
     def time_cats_dogs(self, link_type):
-        self.dvc("add", "data", "--quiet", proc=True)
+        self.dvc("add", "data", proc=True)
 
 
 class AddToCache(BaseRemoteBench):

--- a/benchmarks/checkout.py
+++ b/benchmarks/checkout.py
@@ -15,10 +15,10 @@ class CheckoutBench(BaseBench):
         self.init_git()
         self.init_dvc()
 
-        self.dvc("config", "cache.type", link_type, "--quiet")
+        self.dvc("config", "cache.type", link_type)
 
         self.gen("data", template="cats_dogs")
-        self.dvc("add", "data", "--quiet")
+        self.dvc("add", "data")
         shutil.rmtree("data")
 
     def time_cats_dogs(self, link_type):

--- a/benchmarks/collect.py
+++ b/benchmarks/collect.py
@@ -11,12 +11,12 @@ class CollectBench(BaseBench):
         self.init_dvc()
 
         self.gen("data", template="small")
-        self.dvc("add", "-R", "data", "--quiet")
+        self.dvc("add", "-R", "data")
 
-        self.dvc("status", "--quiet")
+        self.dvc("status")
 
     def time_stages_collection(self):
-        self.dvc("status", "--quiet", proc=True)
+        self.dvc("status", proc=True)
 
 
 class TraverseGitRepoBench(BaseBench):

--- a/benchmarks/gc.py
+++ b/benchmarks/gc.py
@@ -12,7 +12,7 @@ class GCBench(BaseBench):
         self.init_dvc()
 
         self.gen("data", "cats_dogs")
-        self.dvc("add", "data", "--quiet")
+        self.dvc("add", "data")
 
         # remove everything from the local system
         self.dvc("remove", "data.dvc")
@@ -26,8 +26,8 @@ class CloudGCBench(BaseRemoteBench):
         super().setup(remote)
 
         self.gen("data", "large")
-        self.dvc("add", "data", "--quiet")
-        self.dvc("push", "data", "--quiet")
+        self.dvc("add", "data")
+        self.dvc("push", "data")
 
         # remove everything from the local system
         self.dvc("remove", "data.dvc")

--- a/benchmarks/init.py
+++ b/benchmarks/init.py
@@ -3,7 +3,7 @@ from benchmarks.base import BaseBench
 
 class InitNoScmBench(BaseBench):
     def time_init(self):
-        self.dvc("init", "--no-scm", "--quiet", proc=True)
+        self.dvc("init", "--no-scm", proc=True)
 
 
 class InitScmBench(BaseBench):
@@ -12,4 +12,4 @@ class InitScmBench(BaseBench):
         self.init_git()
 
     def time_init(self):
-        self.dvc("init", "--quiet", proc=True)
+        self.dvc("init", proc=True)

--- a/benchmarks/pull.py
+++ b/benchmarks/pull.py
@@ -9,8 +9,8 @@ class PullBench(BaseRemoteBench):
         super().setup(remote)
 
         self.gen("data", "cats_dogs")
-        self.dvc("add", "data", "--quiet")
-        self.dvc("push", "data", "--quiet")
+        self.dvc("add", "data")
+        self.dvc("push", "data")
 
         shutil.rmtree("data")
         shutil.rmtree(os.path.join(".dvc", "cache"))

--- a/benchmarks/push.py
+++ b/benchmarks/push.py
@@ -6,7 +6,7 @@ class PushBench(BaseRemoteBench):
         super().setup(remote)
 
         self.gen("data", template="cats_dogs")
-        self.dvc("add", "data", "--quiet")
+        self.dvc("add", "data")
 
     def time_cats_dogs(self, _):
         self.dvc("push", "-j", "2", proc=True)

--- a/benchmarks/status.py
+++ b/benchmarks/status.py
@@ -17,13 +17,13 @@ class DVCStatusBench(BaseBench):
         os.makedirs(
             os.path.join(self.test_directory.name, "data"), exist_ok=True
         )
-        self.dvc("add", "data", "--quiet")
+        self.dvc("add", "data")
         shutil.copytree(data_path, os.path.join("data", "data"))
         # calculating md5
-        self.dvc("status", "--quiet", return_code=1)
+        self.dvc("status", return_code=1)
 
     def time_status(self):
-        self.dvc("status", "--quiet", return_code=1, proc=True)
+        self.dvc("status", return_code=1, proc=True)
 
 
 class StatusCloudBench(BaseRemoteBench):
@@ -31,11 +31,11 @@ class StatusCloudBench(BaseRemoteBench):
         super().setup(remote)
 
         self.gen("data", "medium")
-        self.dvc("add", "data", "--quiet")
-        self.dvc("push", "data", "--quiet")
+        self.dvc("add", "data")
+        self.dvc("push", "data")
 
     def time_status_c(self, _):
-        self.dvc("status", "data", "--quiet", "-c", proc=True)
+        self.dvc("status", "data", "-c", proc=True)
 
 
 class StatusCloudMissingFilesBench(StatusCloudBench):
@@ -43,10 +43,10 @@ class StatusCloudMissingFilesBench(StatusCloudBench):
         super().setup(remote)
 
         self.gen("data", "large", exist_ok=True)
-        self.dvc("add", "data", "--quiet")
+        self.dvc("add", "data")
 
     def time_status_c_with_missing(self, _):
-        self.dvc("status", "data", "--quiet", "-c", proc=True)
+        self.dvc("status", "data", "-c", proc=True)
 
 
 class DVCIgnoreBench(DVCStatusBench):


### PR DESCRIPTION
Having `--quiet` in benchmarks makes debugging harder.
This change might result in false regressions on "quicker" benchmarks