### PR TITLE
requirements: update DVC to 2.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 scmrepo
 virtualenv==20.0.35
 gitpython==3.1.11
-dvc[all,tests]==2.6.0
+dvc[all,tests]==2.8.3
 awscli==1.19.106
 pre-commit==2.11.1
-pytest==6.2.4
+pytest==6.2.5
 pytest-mock==3.6.1
 feedparser==6.0.8
 pytest-benchmark[histogram]
 ansi2html
 csv2md
+funcy


### PR DESCRIPTION
Seems like after extracting scmrepo the builds on the DVC side started to [fail](https://github.com/iterative/dvc/runs/4394751198?check_suite_focus=true).
Updating DVC should fix it, for now, though it seems to me that long-term solution should be to enable dependabot.