### PR TITLE
benchmarks: help/init increase number of rounds to 100

### DIFF
--- a/tests/benchmarks/cli/commands/test_help.py
+++ b/tests/benchmarks/cli/commands/test_help.py
@@ -1,2 +1,2 @@
 def test_help(bench_dvc):
-    bench_dvc("--help", rounds=10)
+    bench_dvc("--help", rounds=100)

--- a/tests/benchmarks/cli/commands/test_init.py
+++ b/tests/benchmarks/cli/commands/test_init.py
@@ -10,4 +10,4 @@ def test_init(bench_dvc, tmp_dir, scm):
             else:
                 item.unlink()
 
-    bench_dvc("init", setup=_cleanup_dir, rounds=10, warmup_rounds=1)
+    bench_dvc("init", setup=_cleanup_dir, rounds=100, warmup_rounds=1)


### PR DESCRIPTION
The first approach to fix #323 

This change increases the execution time from 10 seconds to about 2 minutes (for both tests). So the influence on our CI should not be noticeable.