### PR TITLE
temporarily reduce dataset size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           DVC_BENCH_AZURE_CONN_STR: ${{ secrets.DVC_BENCH_AZURE_CONN_STR }}
         run: |
-          ./run.sh ${{ matrix.test }} --size large
+          ./run.sh ${{ matrix.test }} --size small
           name=$(echo -n "${{ matrix.test }}" | sed -e 's/[ \t:\/\\"<>|*?]/-/g' -e 's/--*/-/g')
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
       - name: upload raw results


### PR DESCRIPTION
Reducing the dataset size should make it possible to run the benchmarks again while we wait for https://github.com/iterative/dvc/issues/7414 to fix #319 