### PR TITLE
action: use fetch-depth=0 to fetch tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
       uses: actions/checkout@v2
       with:
         path: dvc-bench/dvc
+        fetch-depth: 0
     - name: install PR dvc version
       shell: bash
       working-directory: dvc-bench/dvc


### PR DESCRIPTION
We need to fetch all tags to help `setuptools_scm` deduce correct versioning.

So that we don't see `dvc-0.1.dev1+g81eee05` kind of version numbers in `benchmarks`.

See https://github.com/iterative/dvc/runs/5690662659?check_suite_focus=true#step:4:1773.