### PR TITLE
Use matrix strategy for revs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
   build:
     needs: [gen]
     timeout-minutes: 60
-    name: run ${{ matrix.test }}
+    name: run ${{ matrix.rev }} ${{ matrix.test }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -49,6 +49,7 @@ jobs:
 #        os: [windows-2019, macos-10.15, ubuntu-18.04]
         os: [ubuntu-18.04]
         test: ${{fromJson(needs.gen.outputs.tests)}}
+        rev: ["main", "2.10.0", "2.9.5", "2.8.3", "2.7.3", "2.6.3"]
     steps:
       - uses: actions/setup-python@v2
         with:
@@ -69,13 +70,13 @@ jobs:
         env:
           DVC_BENCH_AZURE_CONN_STR: ${{ secrets.DVC_BENCH_AZURE_CONN_STR }}
         run: |
-          ./run.sh ${{ matrix.test }} --size large
-          name=$(echo -n "${{ matrix.test }}" | sed -e 's/[ \t:\/\\"<>|*?]/-/g' -e 's/--*/-/g')
-          echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
+          ./run.sh ${{matrix.rev}} ${{ matrix.test }} --size large
+          test_name=$(echo -n "${{ matrix.test }}" | awk -F ":" '{print $NF}')
+          echo "ARTIFACT_NAME=${{matrix.rev}}-$test_name" >> $GITHUB_ENV
       - name: upload raw results
         uses: actions/upload-artifact@v2
         with:
-          name: benchmarks-${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: .benchmarks
   publish:
     name: join results and publish
@@ -102,6 +103,10 @@ jobs:
         shell: bash
         run: |
           tree /tmp/benchmarks
+          for el in $(find /tmp/benchmarks -type f); do # cleanup tree for easier reading of report
+            artifact_dir=$(dirname $(dirname $el))
+            mv $el $artifact_dir
+          done
           mkdir html
           echo "$(date)" > raw
           PY_COLORS=1 py.test-benchmark compare $(find /tmp/benchmarks -type f) --histogram histograms --group-by name --csv results.csv --sort name >> raw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
   build:
     needs: [gen]
     timeout-minutes: 60
-    name: run ${{ matrix.rev }} ${{ matrix.test }}
+    name: run ${{ matrix.test.name }} (${{ matrix.rev }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,9 +70,8 @@ jobs:
         env:
           DVC_BENCH_AZURE_CONN_STR: ${{ secrets.DVC_BENCH_AZURE_CONN_STR }}
         run: |
-          ./run.sh ${{matrix.rev}} ${{ matrix.test }} --size large
-          test_name=$(echo -n "${{ matrix.test }}" | awk -F ":" '{print $NF}')
-          echo "ARTIFACT_NAME=${{matrix.rev}}-$test_name" >> $GITHUB_ENV
+          ./run.sh ${{matrix.rev}} ${{ matrix.test.path }} --size large
+          echo "ARTIFACT_NAME=${{matrix.rev}}-${{matrix.test.name}}" >> $GITHUB_ENV
       - name: upload raw results
         uses: actions/upload-artifact@v2
         with:
@@ -103,13 +102,21 @@ jobs:
         shell: bash
         run: |
           tree /tmp/benchmarks
+          mkdir results
           for el in $(find /tmp/benchmarks -type f); do # cleanup tree for easier reading of report
-            artifact_dir=$(dirname $(dirname $el))
-            mv $el $artifact_dir
+            artifact_name=$(basename $(dirname $(dirname $el)))
+            benchmark=$(basename $el)
+            if [[ $benchmark == "*main*.json" ]]; then
+              rev=$(echo $benchmark | cut -d @ -f 2 | cut -d . -f 1)
+              out="results/${artifact_name}_${rev}.json"
+            else
+              out="results/${artifact_name}.json"
+            fi
+            mv $el $out
           done
           mkdir html
           echo "$(date)" > raw
-          PY_COLORS=1 py.test-benchmark compare $(find /tmp/benchmarks -type f) --histogram histograms --group-by name --csv results.csv --sort name >> raw
+          PY_COLORS=1 py.test-benchmark compare $(find results/ -type f) --histogram histograms --group-by name --csv results.csv --sort name >> raw
           cat raw | ansi2html -W > html/index.html
       - name: create md
         if: github.event_name == 'pull_request'

--- a/run.sh
+++ b/run.sh
@@ -5,18 +5,20 @@ set -x
 
 export PIPENV_IGNORE_VIRTUALENVS=1
 
-REVS=("main" "2.10.0" "2.9.5" "2.8.3" "2.7.3" "2.6.3")
+REV=$1
+shift
 
 if [ ! -d "dvc" ]; then
   git clone https://github.com/iterative/dvc
   python -m venv dvc/.venv
 fi
 
-for REV in ${REVS[@]}; do
-  pushd dvc
-  git checkout $REV
-  ./.venv/bin/pip install -e '.[all,tests]'
-  popd
+pushd dvc
+git checkout $REV
+./.venv/bin/pip install -e '.[all,tests]'
+popd
 
-  pytest --benchmark-save $REV $@ --dvc-bin "$(pwd)/dvc/.venv/bin/dvc"
-done
+if [[ $REV == "main" ]]; then
+  REV="main@$(git rev-parse --short=7 HEAD)"
+fi
+pytest --benchmark-save "$REV" $@ --dvc-bin "$(pwd)/dvc/.venv/bin/dvc"

--- a/scripts/ci/list_tests.sh
+++ b/scripts/ci/list_tests.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-echo $(pytest --collect-only tests/benchmarks -q | head -n -2 | jq -R -s -c 'split("\n")[:-1]')
+echo $(pytest --collect-only tests/benchmarks -q | head -n -2 | jq -R -s -c 'split("\n")[:-1] | map({path: ., name: . | split(":")[-1]})')


### PR DESCRIPTION
- `run.sh` now takes revision as the first argument, all other arguments are passed on to `pytest`
- CI build now has the list of revisions to test as part of the matrix strategy (each job is going going to run one test for one revision)
- improve names for jobs/report 