### PR TITLE
fetch tags

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,7 @@ REVS=("main" "2.10.0" "2.9.5" "2.8.3" "2.7.3" "2.6.3")
 
 if [ ! -d "dvc" ]; then
   git clone https://github.com/iterative/dvc
+  git fetch --tags
   python -m venv dvc/.venv
 fi
 


### PR DESCRIPTION
Fetch tags so that the version shows up correctly in `dvc version` and during `pip install`.