### PR TITLE
bench: use mnist instead of large

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,5 +1,7 @@
 [core]
     remote = bench_s3_public
+['remote "dataset_registry"']
+    url = https://remote.dvc.org/dataset-registry
 ['remote "bench_s3"']
     url = s3://dvc-bench/cache
 ['remote "bench_s3_public"']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
           - tiny
           - small
           - large
+          - mnist
 
 env:
   DVC_TEST: "true"
@@ -76,7 +77,7 @@ jobs:
           DVC_BENCH_AZURE_CONN_STR: ${{ secrets.DVC_BENCH_AZURE_CONN_STR }}
           DATASET_SIZE: ${{ github.event.inputs.dataset }}
         run: |
-          ./run.sh ${{ matrix.test.path }} --size ${DATASET_SIZE:-large}
+          ./run.sh ${{ matrix.test.path }} --size ${DATASET_SIZE:-mnist}
       - name: upload raw results
         uses: actions/upload-artifact@v2
         with:

--- a/data/mnist/.gitignore
+++ b/data/mnist/.gitignore
@@ -1,0 +1,1 @@
+/dataset

--- a/data/mnist/dataset.dvc
+++ b/data/mnist/dataset.dvc
@@ -1,0 +1,7 @@
+outs:
+- md5: e42412b82dcab425ce9c7e2d0abdfb78.dir
+  size: 19258482
+  nfiles: 70000
+  path: dataset
+  remote: dataset_registry
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--size",
-        choices=["tiny", "small", "large"],
+        choices=["tiny", "small", "large", "mnist"],
         default="small",
         help="Size of the dataset/datafile to use in tests",
     )


### PR DESCRIPTION
From https://github.com/iterative/dataset-registry , used by docs and vscode teams in their workflows, which is a better benchmark than a 20K large dataset.