### PR TITLE
bench: don't forget to modify fullname

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,11 @@ jobs:
           echo "dataset: ${DATASET_SIZE:-mnist}" >> raw
           PY_COLORS=1 py.test-benchmark compare $(find results/ -type f) --histogram histograms --group-by name --csv results.csv --sort name >> raw
           cat raw | ansi2html -W > html/index.html
+      - name: upload joint results.csv
+        uses: actions/upload-artifact@v2
+        with:
+          name: results.csv
+          path: results.csv
       - name: create md
         if: github.event_name == 'pull_request'
         id: get-comment-body

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -23,7 +23,10 @@ def make_bench(request):
         bench = pytest_benchmark.plugin.benchmark.__pytest_wrapped__.obj(
             request
         )
-        bench.name += f"-{name}"
+        suffix = f"-{name}"
+        bench.name += suffix
+        bench.fullname += suffix
+
         return bench
 
     return _make_bench


### PR DESCRIPTION
We currently modify `name`, but not `fullname`, which results in generated `csv` not having correct name column.