### PR TITLE
fix flake8 URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     exclude: '^dvc/'
     files: '.*\.py'
     language_version: python3
-  repo: https://gitlab.com/pycqa/flake8
+  repo: https://github.com/pycqa/flake8
   rev: 3.7.9
 - hooks:
     - args:


### PR DESCRIPTION
CI lint step was broken because of updated flake8 URL:

https://github.com/PyCQA/flake8/issues/1737
