### PR TITLE
bench: don't use dvc.odb.local.path

### DIFF
--- a/tests/benchmarks/cli/commands/test_checkout.py
+++ b/tests/benchmarks/cli/commands/test_checkout.py
@@ -20,7 +20,9 @@ def generate_test(*, link_type="copy"):
     def _test_checkout_func(bench_dvc, tmp_dir, dvc, make_dataset):
         dataset = make_dataset(dvcfile=True, cache=True, files=False)
 
-        _skip_unsupported_link(dvc.odb.local.path, tmp_dir, link_type)
+        _skip_unsupported_link(
+            (tmp_dir / ".dvc" / "cache"), tmp_dir, link_type
+        )
 
         with dvc.config.edit() as conf:
             conf["cache"]["type"] = link_type

--- a/tests/benchmarks/cli/stories/use-cases/test_sharing.py
+++ b/tests/benchmarks/cli/stories/use-cases/test_sharing.py
@@ -9,7 +9,7 @@ def test_sharing(bench_dvc, tmp_dir, dvc, dataset, remote):
     bench_dvc("push", name="noop")
 
     shutil.rmtree(dataset)
-    shutil.rmtree(dvc.odb.local.path)
+    shutil.rmtree(tmp_dir / ".dvc" / "cache")
 
     bench_dvc("pull")
     bench_dvc("pull", name="noop")


### PR DESCRIPTION
`dvc.odb` was renamed to `dvc.cache` in https://github.com/iterative/dvc/pull/8987

Fixes CI https://github.com/iterative/dvc-bench/actions/runs/4169046364/jobs/7216558892