### PR TITLE
benchmark s3 sharing use case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,11 +73,12 @@ jobs:
         run: |
             pip install -r requirements.txt
             pip install git+https://github.com/iterative/dvc
+            pip install git+https://github.com/iterative/dvc-s3#egg=dvc-s3[tests]
       - name: run benchmarks
         shell: bash
         env:
           DVC_BENCH_AZURE_CONN_STR: ${{ secrets.DVC_BENCH_AZURE_CONN_STR }}
-        run: pytest --benchmark-save ${{ matrix.test.name }} --benchmark-group-by func --dvc-revs main,2.45.0,2.41.1,2.40.0,2.39.0,2.18.1,2.11.0,2.6.3 ${{ matrix.test.path }} --size ${DATASET}
+        run: pytest --benchmark-save ${{ matrix.test.name }} --benchmark-group-by func --dvc-revs main,2.45.0,2.41.1,2.40.0,2.39.0,2.18.1,2.11.0,2.6.3 ${{ matrix.test.path }} --size ${DATASET} --enable-s3
       - name: upload raw results
         uses: actions/upload-artifact@v3
         with:

--- a/scripts/ci/list_tests.sh
+++ b/scripts/ci/list_tests.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-echo $(pytest --collect-only tests/benchmarks -q | grep tests/benchmarks | sed "s/\[None.*\]//g" | jq -R -s -c 'split("\n")[:-1] | map({path: ., name: . | split(":")[-1]})')
+echo $(pytest --collect-only tests/benchmarks -q | grep tests/benchmarks | sed 's/\[.*None.*\]//g' | jq -R -s -c 'split("\n")[:-1] | map({path: ., name: . | split(":")[-1]})')

--- a/tests/benchmarks/cli/stories/use-cases/test_sharing.py
+++ b/tests/benchmarks/cli/stories/use-cases/test_sharing.py
@@ -1,5 +1,6 @@
 import shutil
 
+
 def pytest_generate_tests(metafunc):
     if "remote" in metafunc.fixturenames:
         config = metafunc.config.dvc_config

--- a/tests/benchmarks/cli/stories/use-cases/test_sharing.py
+++ b/tests/benchmarks/cli/stories/use-cases/test_sharing.py
@@ -1,5 +1,12 @@
 import shutil
 
+def pytest_generate_tests(metafunc):
+    if "remote" in metafunc.fixturenames:
+        config = metafunc.config.dvc_config
+        remotes = set(config.enabled_remotes)
+        remotes.add(config.remote)
+        metafunc.parametrize("remote", remotes, indirect=True)
+
 
 def test_sharing(bench_dvc, tmp_dir, dvc, dataset, remote):
     bench_dvc("add", dataset)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -52,9 +52,13 @@ def dvc_bin(
         if not venv:
             venv = make_dvc_venv(dvc_rev)
             venv.run("pip install -U pip")
+            if test_config.extras:
+                egg = "#egg=dvc[{}]".format(",".join(test_config.extras))
+            else:
+                egg = ""
+            venv.run(f"pip install git+file://{dvc_git_repo}@{dvc_rev}{egg}")
             if dvc_rev in ["2.18.1", "2.11.0", "2.6.3"]:
                 venv.run("pip install fsspec==2022.11.0")
-            venv.run(f"pip install git+file://{dvc_git_repo}@{dvc_rev}")
             dvc_venvs[dvc_rev] = venv
         dvc_bin = venv.virtualenv / "bin" / "dvc"
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,7 @@ class DVCTestConfig:
         self.dvc_git_repo = DEFAULT_DVC_GIT_REPO
         self.project_rev = None
         self.project_git_repo = DEFAULT_PROJECT_GIT_REPO
+        self.extras = set()
 
     def requires(self, remote_name):
         if remote_name not in REMOTES or remote_name in self.enabled_remotes:
@@ -235,3 +236,15 @@ def pytest_configure(config):
                 enabled_remotes.remove(remote)
             except KeyError:
                 pass
+
+    all_extras = {
+        "azure",
+        "gdrive",
+        "gs",
+        "hdfs",
+        "s3",
+        "ssh",
+        "webdav",
+        "webhdfs",
+    }
+    config.dvc_config.extras = all_extras.intersection(remotes)


### PR DESCRIPTION
related: https://github.com/iterative/dvc/issues/9108

- `--enable-<remote>` and `--remote <remote>` now actually benchmarks the specified remotes in `tests/benchmarks/cli/stories/use-cases/test_sharing.py

Things that are not changed in this PR:

- command specific tests still do not run against non-local remotes
- `remote_dataset` is still unimplemented
- remote tests are not run against real clouds (default pytest-servers emulators/docker only)