### PR TITLE
ci: use CML instead of create-pr-comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ env:
   FORCE_COLOR: "1"
   DATASET: ${{ github.event.inputs.dataset || ( github.event_name == 'schedule' && 'mnist' || 'small' ) }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -91,6 +95,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: iterative/setup-cml@v1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -102,25 +107,18 @@ jobs:
           pip install git+https://github.com/iterative/dvc#egg=dvc[testing]
       - name: download ubuntu results
         uses: actions/download-artifact@v3
+
       - name: compare results
         shell: bash
         run: ./scripts/ci/gen_html.sh
-      - name: create md
-        if: github.event_name == 'pull_request'
-        id: get-comment-body
-        run: |
-          cat raw
-          body="\`\`\`\n$(cat raw | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g")\n\`\`\`"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo ::set-output name=body::$body
+
       - name: post comment
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.get-comment-body.outputs.body }}
+        run: |
+          cml comment update --watermark-title='dvc-bench report' report.md
+
       - name: deploy new benchmarks to github pages
         if: ${{ github.event_name == 'schedule' }}
         uses: peaceiris/actions-gh-pages@v3

--- a/scripts/ci/gen_html.sh
+++ b/scripts/ci/gen_html.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 tree .benchmarks
-rm -rf html
+rm -rf html report.md
 mkdir html
 echo bench.dvc.org > html/CNAME
 echo > raw
@@ -12,6 +12,9 @@ echo "$(date)" >> raw
 echo "dataset: ${DATASET}" >> raw
 echo "project: example-get-started" >> raw
 cat raw | ansi2html -W > html/index.html
+
+echo '```' > report.md
+cat raw >> report.md
 
 for file in $(find .benchmarks -type f);
 do
@@ -21,4 +24,7 @@ do
   dvc plots show -o tmp_html
   cat tmp_html/index.html >> html/index.html
   cat raw | ansi2html -W >> html/index.html
+  cat raw | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> report.md
 done
+
+echo '```' >> report.md


### PR DESCRIPTION
- drops deprecated GHA `set-output` usage
- uses `cml comment` for PR comment generation 
- also fixes issue where PR comments only had the last-run benchmark results instead of the full concat'd results