### PR TITLE
ci: set s3 timeout to 4 hrs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
     name: run S3 benchmarks
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
We may also need to just reduce the # of revs we test for S3, aws token timeout is currently 4 hours, not sure it is worth extending it