### PR TITLE
Add missing permission to publish GH Page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,7 @@ jobs:
       pages: write
       pull-requests: write
       contents: write
+      id-token: write
     steps:
       - uses: iterative/setup-cml@v1
       - uses: actions/setup-python@v4


### PR DESCRIPTION
From example workflows I see that it needs this set of permissions:
```yaml
# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
permissions:
  contents: read
  pages: write
  id-token: write
```