### PR TITLE
ci: allow failures in real remote tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     name: run ${{ matrix.test.name }}
     timeout-minutes: 480
+    continue-on-error: true
     permissions:
       id-token: write
     steps:
@@ -177,6 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     name: run ${{ matrix.test.name }}
     timeout-minutes: 480
+    continue-on-error: true
     permissions:
       id-token: write
     environment: ${{ github.event_name == 'schedule' && 'github-actions' || ''}}
@@ -245,6 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     name: run ${{ matrix.test.name }}
     timeout-minutes: 480
+    continue-on-error: true
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Allows bench.dvc.org to still be updated as long as the main benchmarks run successfully (so s3/azure/gcs timeouts do not prevent the overall build)