### PR TITLE
requirements: add explicit pygal dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ virtualenv
 dvc[s3,tests]>=2.43.1
 pre-commit==2.21.0
 pytest-benchmark[histogram]
+pygal>=3.0.3
+importlib_metadata
 pytest-virtualenv
 ansi2html
 csv2md


### PR DESCRIPTION
Should fix deploy/publish CI: https://github.com/iterative/dvc-bench/actions/runs/6937330780/job/18875133391

pytest-benchmark[histogram] depends on pygal, recent pygal changes now use `importlib_metadata` but the dependency is missing from the pygal install requirements

see: https://github.com/Kozea/pygal/issues/545