### PR TITLE
data: use 2.x-compatible dvcfiles for openorca and use-cars

### DIFF
--- a/data/openorca/dataset.dvc
+++ b/data/openorca/dataset.dvc
@@ -1,7 +1,6 @@
 outs:
-- md5: 9b0cbf577587304975492f307de0e6c6.dir
+- md5: df6beb673fda30e43e6bd4c174ac8b0c.dir
   size: 7204625544
   nfiles: 1
-  hash: md5
   path: dataset
   desc: https://www.kaggle.com/datasets/thedevastator/open-orca-augmented-flan-dataset

--- a/data/used-cars/dataset.dvc
+++ b/data/used-cars/dataset.dvc
@@ -1,7 +1,6 @@
 outs:
-- md5: 5eedb5fdef900284633ef5dcab82044a.dir
+- md5: 67e9af5964e832626d644729569d659f.dir
   size: 1447955215
   nfiles: 1
-  hash: md5
   path: dataset
   desc: https://www.kaggle.com/datasets/austinreese/craigslist-carstrucks-data


### PR DESCRIPTION
For now we still need to be compatible with 2.x