### PR TITLE
ci: use pre-commit.ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,6 @@ jobs:
           pip install -U pip
           pip install wheel
           pip install -r requirements.txt
-      - name: check project styling
-        run: pre-commit run --all-files --show-diff-on-failure
   gen:
     runs-on: ubuntu-latest
     outputs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 virtualenv
 dvc[s3,tests]>=3.33.3
-pre-commit==3.5.0
 pytest-benchmark[histogram]
 pygal>=3.0.3
 importlib_metadata


### PR DESCRIPTION
- removes pinned pre-commit from requirements.txt and build workflow in favor of using pre-commit.ci (latest pinned pre-commit now causes pip conflicts due to incompatible platformdirs ranges between `dvc` and `virtualenv`)