### PR TITLE
pin pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "-ra -p no:hydra_pytest"
+addopts = "-ra"
 testpaths = [
     "tests",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ansi2html
 csv2md
 funcy
 pandas
+pytest==8.0


### PR DESCRIPTION
Newer release of `pytest` 8.1.0 is breaking `flaky` plugin. Pinning the pytest version temporarily.

```pytb
Run echo "tests=$(./scripts/ci/list_tests.sh)" >> $GITHUB_OUTPUT
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.13/x64/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 195, in console_main
    code = main()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 153, in main
    config = _prepareconfig(args, plugins)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 335, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/helpconfig.py", line 105, in pytest_cmdline_parse
    config = yield
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1141, in pytest_cmdline_parse
    self.parse(args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1490, in parse
    self._preparse(args, addopts=addopts)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1377, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_manager.py", line 414, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/flaky/flaky_pytest_plugin.py", line 5, in <module>
    from _pytest.runner import call_runtest_hook  # pylint:disable=import-error
ImportError: cannot import name 'call_runtest_hook' from '_pytest.runner' (/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/runner.py)
```