### PR TITLE
Fix OpenID Connect for Google Cloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -397,6 +397,7 @@ jobs:
     continue-on-error: true
     permissions:
       id-token: write
+    environment: google-cloud
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -435,8 +436,7 @@ jobs:
         name: 'Authenticate to GCP'
         uses: 'google-github-actions/auth@v2.1.5'
         with:
-          create_credentials_file: true
-          workload_identity_provider: 'projects/385088528371/locations/global/workloadIdentityPools/iterative-sandbox/providers/github'
+          workload_identity_provider: 'projects/385088528371/locations/global/workloadIdentityPools/github/providers/github'
           service_account: 'dvc-bench@iterative-sandbox.iam.gserviceaccount.com'
       - name: configure real GS DVC env
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
See https://github.com/iterative/dvc-bench/actions/runs/10840696905/job/30083510194

I've replaced the ClickOops hot mess we had with my Terraform recipe under a new Google Cloud provider; now it works as intended.

Also, switched to use `environment`-based subject conditions for extra security.